### PR TITLE
updated undo to drop api requests

### DIFF
--- a/whales/static/js/play-controller.js
+++ b/whales/static/js/play-controller.js
@@ -6,7 +6,6 @@ function Controller() {
   let redSquare = "";
   var ignorePendingAPI = false;
 
-
   function mouseoverEntryHandler(square) {
     if (!model.canPlayerMove()) return;
 
@@ -87,11 +86,11 @@ function Controller() {
         },
         response => {
           // TODO: better error handling.
-          if (!ignorePendingAPI){
-          model.setGamePGN(response.pgn);
-          updateViewWithMove({ animate: true });
-        }
-        ignorePendingAPI = false; //reset
+          if (!ignorePendingAPI) {
+            model.setGamePGN(response.pgn);
+            updateViewWithMove({ animate: true });
+          }
+          ignorePendingAPI = false; //reset
         }
       );
     }
@@ -103,9 +102,9 @@ function Controller() {
   }
 
   function undoHandler() {
-   // This method allows for the api return to be ignored.
-   // if it is the computers turn, allow the player move to be undone, 
-   // and ignore the computer's move
+    // This method allows for the api return to be ignored.
+    // if it is the computers turn, allow the player move to be undone,
+    // and ignore the computer's move
 
     if (!model.isPlayerTurn()) {
       ignorePendingAPI = true;

--- a/whales/static/js/play-model.js
+++ b/whales/static/js/play-model.js
@@ -50,7 +50,7 @@ function Model(params) {
 
   this.undoLastMove = () => {
     // Dont undo the first move if computer is white
-    if(!this.hasPlayerMoved() && playerColor == "b") {
+    if (!this.hasPlayerMoved() && playerColor == "b") {
       return;
     }
     //undo player and computer move
@@ -60,7 +60,6 @@ function Model(params) {
     //undo only your move if it is the computers turn
     game.undo();
   };
-
 
   this.getSquareOfKing = color => {
     let square;


### PR DESCRIPTION
Changes the undo handlers so that the user can undo at any state, properly ignoring pending API requests and handling exactly what should be undone.

Note: this does not lock the thread, but from my reading I think that we can ignore that in java script