### PR TITLE
Make frontend choose random move on timeout

### DIFF
--- a/whales/static/js/play-controller.js
+++ b/whales/static/js/play-controller.js
@@ -117,6 +117,21 @@ function Controller() {
     }
   }
 
+  function handleAPIError(errorMessage) {
+    /**
+     * Determine if error is a timeout, in which case randomly select
+     * legal move, or call view error display function.
+     */
+    if (errorMessage === "timeout") {
+      if (model.canComputerMove()) {
+        model.makeRandomMove();
+        updateViewWithMove({ animate: true });
+      }
+    } else {
+      view.crashAndBurn(errorMessage);
+    }
+  }
+
   function tryMakeComputerMove() {
     /**
      *  Attempt to make computer move.
@@ -140,7 +155,7 @@ function Controller() {
           model.setGamePGN(response.pgn);
           updateViewWithMove({ animate: true });
         },
-        view.crashAndBurn
+        handleAPIError
       );
     }
   }

--- a/whales/static/js/play-model.js
+++ b/whales/static/js/play-model.js
@@ -46,6 +46,21 @@ function Model(params) {
     });
   };
 
+  this.getRandomMove = () => {
+    /**
+     * Return a randomly chosen legal move.
+     */
+    let moves = game.moves({ verbose: true });
+    return moves[Math.floor(Math.random() * moves.length)];
+  };
+
+  this.makeRandomMove = () => {
+    /**
+     * Make randomly chosen legal move.
+     */
+    game.move(this.getRandomMove());
+  };
+
   this.getLastMoveSquares = () => {
     /**
      * Return start and end squares of previous move.


### PR DESCRIPTION
Note: while #41 hopefully makes this redundant, there is still a 60 second timeout on the frontend, and this is a useful failsafe in case anything goes wrong with the Python logic.

https://trello.com/c/ByWt3jmO/134-choose-random-move-in-the-event-of-timeout