### PR TITLE
Return proper error code for GET /api/v1/http

### DIFF
--- a/whales/server.py
+++ b/whales/server.py
@@ -78,12 +78,12 @@ def page_about():
     return flask.send_from_directory("html", "about.html")
 
 
-@app.route("/<path:path>")
-def static(path):
+@app.route("/api/v1/http")
+def http_endpoint_get():
     """
-    Serve non-HTML static files.
+    Error with method not allowed.
     """
-    return flask.send_from_directory("static", path)
+    flask.abort(405)
 
 
 @app.route("/api/v1/http", methods=["POST"])
@@ -100,3 +100,11 @@ def http_endpoint():
     else:
         response = whales.api.error_response("invalid or missing JSON")
     return response
+
+
+@app.route("/<path:path>")
+def static(path):
+    """
+    Serve non-HTML static files.
+    """
+    return flask.send_from_directory("static", path)


### PR DESCRIPTION
Return 405 instead of 404 for `/api/v1/http`

Fixes https://trello.com/b/NXyDnIRr/tasks

Note: I couldn't find a more elegant way of doing this; if anyone has any ideas please let me know! Alternatively, if this is too ugly (it's a super small bug that literally no one cares about) feel free to close this PR.